### PR TITLE
Remove obsolete upper bound version pin for importlib-metadata, typing-extensions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -23,9 +23,9 @@ requirements:
   run:
     - python >=3.8
     - docutils >=0.7
-    - importlib-metadata >=1.6,<5.0
+    - importlib-metadata >=1.6
     - pydantic >=2
-    - typing-extensions >=3.7.4,<5.0
+    - typing-extensions >=3.7.4
 
 test:
   imports:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Closing #8
